### PR TITLE
Feature/responsive img

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,40 +9,30 @@ A react component that accepts a high-res source image and produces a magnifier 
 
 ## Usage
 
-```bash
-> npm install --save react-image-magnifier
-```
-
 ```jsx
-var ImageMagnifer = require('react-image-magnifier');
+import ImageMagnifer from 'react-image-magnifier';
 
-var App = React.createClass({
-
-    render () {
-        return (
-            <ImageMagnifier
-                image={{
-                    src: "img/beach-small.jpg",
-                    width: 400,
-                    height: 300
-                }}
-                zoomImage={{
-                    src: "img/beach-large.jpg",
-                    width: 1600,
-                    height: 1200
-                }}
-                cursorOffset={{ x: 80, y: -80 }}
-            />
-        );
-    }
-});
+const App = () => (
+  <ImageMagnifier
+    src: "img/beach-small.jpg",
+    height: 300
+    width: 400,
+    zoomImage={{
+      width: 1600,
+      height: 1200
+    }}
+    cursorOffset={{ x: 80, y: -80 }}
+  />
+)
 ```
 
 ## API (props)
 
 | Prop | Required | Default  | Type | Description |
-| :------------ |:---:|:---------------:| :---------------| :-----|
-| `image` | YES | | `{ src, width, height }` | the src, size of the non-zoomed-in image |
-| `zoomImage` | YES | | `{ src, width, height }` | the src, size of the zoomed-in image |
-| `cursorOffset` | NO | `{ x: 0, y: 0 }` | `{ x, y }` | the offset of the zoom bubble from the cursor |
-| `size` | NO | `200` | `Number` | the size of the magnifier window |
+| :------------- |:---:|:----------------:| :--------------------| :-----|
+| `src`          | YES |                  | `String`             | the src |
+| `height`       |  NO | `"auto"`         | `Number` or `String` | the height non-zoomed-in image |
+| `width`        |  NO | `"100%"`         | `Number` or `String` | the width of the non-zoomed-in image |
+| `zoomImage`    |  NO | src size         | `{ width, height }`  | size of the zoomed-in image |
+| `cursorOffset` |  NO | `{ x: 0, y: 0 }` | `{ x, y }`           | the offset of the zoom bubble from the cursor |
+| `size`         |  NO | `200`            | `Number`             | the size of the magnifier window |

--- a/src/ImageMagnifier.js
+++ b/src/ImageMagnifier.js
@@ -24,16 +24,17 @@ var Magnifier = React.createClass({
       y: React.PropTypes.number.isRequired
     }).isRequired,
 
+    // the URL of the image
+    src: React.PropTypes.string.isRequired,
+
     // the size of the non-zoomed-in image
     smallImage: React.PropTypes.shape({
-      src: React.PropTypes.string.isRequired,
       width: React.PropTypes.number.isRequired,
       height: React.PropTypes.number.isRequired
     }).isRequired,
 
     // the size of the zoomed-in image
     zoomImage: React.PropTypes.shape({
-      src: React.PropTypes.string.isRequired,
       width: React.PropTypes.number.isRequired,
       height: React.PropTypes.number.isRequired
     }).isRequired
@@ -44,8 +45,8 @@ var Magnifier = React.createClass({
     var halfSize = props.size / 2;
     var magX = props.zoomImage.width / props.smallImage.width;
     var magY = props.zoomImage.height / props.smallImage.height;
-    var bgX = -(props.offsetX*magX - halfSize);
-    var bgY = -(props.offsetY*magY - halfSize);
+    var bgX = -(props.offsetX * magX - halfSize);
+    var bgY = -(props.offsetY * magY - halfSize);
     var isVisible = props.offsetY < props.smallImage.height &&
                     props.offsetX < props.smallImage.width &&
                     props.offsetY > 0 &&
@@ -62,12 +63,12 @@ var Magnifier = React.createClass({
         marginTop: -halfSize + props.cursorOffset.y,
         backgroundColor: 'white',
         borderRadius: props.size,
-        boxShadow: `1px 1px 6px rgba(0,0,0,0.3)`
+        boxShadow: '1px 1px 6px rgba(0,0,0,0.3)'
       }}>
           <div style={{
             width: props.size,
             height: props.size,
-            backgroundImage: `url(${props.zoomImage.src})`,
+            backgroundImage: `url(${props.src})`,
             backgroundRepeat: 'no-repeat',
             backgroundPosition: `${bgX}px ${bgY}px`,
             borderRadius: props.size
@@ -90,7 +91,6 @@ function getOffset(el) {
 
 var ImageMagnifier = React.createClass({
   propTypes: {
-
     // the size of the magnifier window
     size: React.PropTypes.number,
 
@@ -100,16 +100,17 @@ var ImageMagnifier = React.createClass({
       y: React.PropTypes.number.isRequired
     }),
 
+    // the URL of the image
+    src: React.PropTypes.string.isRequired,
+
     // the size of the non-zoomed-in image
     image: React.PropTypes.shape({
-      src: React.PropTypes.string.isRequired,
       width: React.PropTypes.number.isRequired,
       height: React.PropTypes.number.isRequired
     }).isRequired,
 
     // the size of the zoomed-in image
     zoomImage: React.PropTypes.shape({
-      src: React.PropTypes.string.isRequired,
       width: React.PropTypes.number.isRequired,
       height: React.PropTypes.number.isRequired
     }).isRequired
@@ -165,6 +166,7 @@ var ImageMagnifier = React.createClass({
         cursorOffset={this.props.cursorOffset}
         size={this.props.size}
         smallImage={this.props.image}
+        src={this.props.src}
         zoomImage={this.props.zoomImage}
         {...this.state}
       />,
@@ -176,7 +178,7 @@ var ImageMagnifier = React.createClass({
       <img
         height={this.props.image.height}
         ref={node => this.img = node}
-        src={this.props.image.src}
+        src={this.props.src}
         width={this.props.image.width}
       />
     );

--- a/src/ImageMagnifier.js
+++ b/src/ImageMagnifier.js
@@ -1,5 +1,5 @@
-import React, { PropTypes } from "react";
-import ReactDOM from "react-dom";
+import React, { PropTypes } from 'react';
+import ReactDOM from 'react-dom';
 
 function getImageSize(src) {
   var image = new Image();
@@ -12,41 +12,24 @@ function getImageSize(src) {
 
 var Magnifier = React.createClass({
   propTypes: {
-    // the size of the magnifier window
-    size: PropTypes.number.isRequired,
-
-    // x position on screen
-    x: PropTypes.number.isRequired,
-
-    // y position on screen
-    y: PropTypes.number.isRequired,
-
-    // x position relative to the image
-    offsetX: PropTypes.number.isRequired,
-
-    // y position relative to the image
-    offsetY: PropTypes.number.isRequired,
-
-    // the offset of the zoom bubble from the cursor
+    size: PropTypes.number.isRequired, // the size of the magnifier window
+    x: PropTypes.number.isRequired, // x position on screen
+    y: PropTypes.number.isRequired, // y position on screen
+    offsetX: PropTypes.number.isRequired, // x position relative to the image
+    offsetY: PropTypes.number.isRequired, // y position relative to the image
     cursorOffset: PropTypes.shape({
       x: PropTypes.number.isRequired,
       y: PropTypes.number.isRequired,
-    }).isRequired,
-
-    // the URL of the image
-    src: PropTypes.string.isRequired,
-
-    // the size of the non-zoomed-in image
+    }).isRequired, // the offset of the zoom bubble from the cursor
+    src: PropTypes.string.isRequired, // the URL of the image
     smallImage: PropTypes.shape({
       height: PropTypes.number.isRequired,
       width: PropTypes.number.isRequired,
-    }).isRequired,
-
-    // the size of the zoomed-in image
+    }).isRequired, // the size of the non-zoomed-in image
     zoomImage: PropTypes.shape({
       height: PropTypes.number.isRequired,
       width: PropTypes.number.isRequired,
-    }),
+    }), // the size of the zoomed-in image
   },
 
   render() {
@@ -101,27 +84,18 @@ function getOffset(el) {
 
 var ImageMagnifier = React.createClass({
   propTypes: {
-    // the size of the magnifier window
-    size: PropTypes.number,
-
-    // the offset of the zoom bubble from the cursor
+    size: PropTypes.number, // the size of the magnifier window
     cursorOffset: PropTypes.shape({
       x: PropTypes.number.isRequired,
       y: PropTypes.number.isRequired,
-    }),
-
-    // the URL of the image
-    src: PropTypes.string.isRequired,
-
-    // the size of the non-zoomed-in image
-    height: PropTypes.number,
-    width: PropTypes.number,
-
-    // the size of the zoomed-in image
+    }), // the offset of the zoom bubble from the cursor
+    src: PropTypes.string.isRequired, // the URL of the image
+    height: PropTypes.number, // the size of the non-zoomed-in image
+    width: PropTypes.number, // the size of the non-zoomed-in image
     zoomImage: PropTypes.shape({
       height: PropTypes.number.isRequired,
       width: PropTypes.number.isRequired,
-    }),
+    }), // the size of the zoomed-in image
   },
 
   portalElement: null,
@@ -129,7 +103,9 @@ var ImageMagnifier = React.createClass({
   getDefaultProps() {
     return {
       size: 200,
-      cursorOffset: { x: 0, y: 0 }
+      cursorOffset: { x: 0, y: 0 },
+      height: "auto",
+      width: "100%",
     };
   },
 
@@ -174,8 +150,8 @@ var ImageMagnifier = React.createClass({
         cursorOffset={this.props.cursorOffset}
         size={this.props.size}
         smallImage={{
-          height: this.props.height || this.img.clientHeight,
-          width: this.props.width || this.img.clientWidth,
+          height: this.img.clientHeight,
+          width: this.img.clientWidth,
         }}
         src={this.props.src}
         zoomImage={this.props.zoomImage}
@@ -190,8 +166,8 @@ var ImageMagnifier = React.createClass({
         ref={node => this.img = node}
         src={this.props.src}
         style={{
-          height: this.props.height || "auto",
-          width: this.props.width || "100%",
+          height: this.props.height,
+          width: this.props.width,
         }}
       />
     );

--- a/src/ImageMagnifier.js
+++ b/src/ImageMagnifier.js
@@ -1,6 +1,15 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 
+function getImageSize(src) {
+  var image = new Image();
+  image.src = src;
+  return {
+    height: image.height,
+    width: image.width,
+  };
+}
+
 var Magnifier = React.createClass({
   propTypes: {
     // the size of the magnifier window
@@ -21,7 +30,7 @@ var Magnifier = React.createClass({
     // the offset of the zoom bubble from the cursor
     cursorOffset: React.PropTypes.shape({
       x: React.PropTypes.number.isRequired,
-      y: React.PropTypes.number.isRequired
+      y: React.PropTypes.number.isRequired,
     }).isRequired,
 
     // the URL of the image
@@ -29,22 +38,23 @@ var Magnifier = React.createClass({
 
     // the size of the non-zoomed-in image
     smallImage: React.PropTypes.shape({
+      height: React.PropTypes.number.isRequired,
       width: React.PropTypes.number.isRequired,
-      height: React.PropTypes.number.isRequired
     }).isRequired,
 
     // the size of the zoomed-in image
     zoomImage: React.PropTypes.shape({
+      height: React.PropTypes.number.isRequired,
       width: React.PropTypes.number.isRequired,
-      height: React.PropTypes.number.isRequired
-    }).isRequired
+    }),
   },
 
   render() {
     var props = this.props;
     var halfSize = props.size / 2;
-    var magX = props.zoomImage.width / props.smallImage.width;
-    var magY = props.zoomImage.height / props.smallImage.height;
+    var imageSize = this.props.zoomImage ? this.props.zoomImage : getImageSize(this.props.src);
+    var magX = imageSize.width / props.smallImage.width;
+    var magY = imageSize.height / props.smallImage.height;
     var bgX = -(props.offsetX * magX - halfSize);
     var bgY = -(props.offsetY * magY - halfSize);
     var isVisible = props.offsetY < props.smallImage.height &&
@@ -97,7 +107,7 @@ var ImageMagnifier = React.createClass({
     // the offset of the zoom bubble from the cursor
     cursorOffset: React.PropTypes.shape({
       x: React.PropTypes.number.isRequired,
-      y: React.PropTypes.number.isRequired
+      y: React.PropTypes.number.isRequired,
     }),
 
     // the URL of the image
@@ -105,15 +115,15 @@ var ImageMagnifier = React.createClass({
 
     // the size of the non-zoomed-in image
     image: React.PropTypes.shape({
+      height: React.PropTypes.number.isRequired,
       width: React.PropTypes.number.isRequired,
-      height: React.PropTypes.number.isRequired
     }).isRequired,
 
     // the size of the zoomed-in image
     zoomImage: React.PropTypes.shape({
+      height: React.PropTypes.number.isRequired,
       width: React.PropTypes.number.isRequired,
-      height: React.PropTypes.number.isRequired
-    }).isRequired
+    }),
   },
 
   portalElement: null,

--- a/src/ImageMagnifier.js
+++ b/src/ImageMagnifier.js
@@ -1,5 +1,5 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
+import React, { PropTypes } from "react";
+import ReactDOM from "react-dom";
 
 function getImageSize(src) {
   var image = new Image();
@@ -13,39 +13,39 @@ function getImageSize(src) {
 var Magnifier = React.createClass({
   propTypes: {
     // the size of the magnifier window
-    size: React.PropTypes.number.isRequired,
+    size: PropTypes.number.isRequired,
 
     // x position on screen
-    x: React.PropTypes.number.isRequired,
+    x: PropTypes.number.isRequired,
 
     // y position on screen
-    y: React.PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
 
     // x position relative to the image
-    offsetX: React.PropTypes.number.isRequired,
+    offsetX: PropTypes.number.isRequired,
 
     // y position relative to the image
-    offsetY: React.PropTypes.number.isRequired,
+    offsetY: PropTypes.number.isRequired,
 
     // the offset of the zoom bubble from the cursor
-    cursorOffset: React.PropTypes.shape({
-      x: React.PropTypes.number.isRequired,
-      y: React.PropTypes.number.isRequired,
+    cursorOffset: PropTypes.shape({
+      x: PropTypes.number.isRequired,
+      y: PropTypes.number.isRequired,
     }).isRequired,
 
     // the URL of the image
-    src: React.PropTypes.string.isRequired,
+    src: PropTypes.string.isRequired,
 
     // the size of the non-zoomed-in image
-    smallImage: React.PropTypes.shape({
-      height: React.PropTypes.number.isRequired,
-      width: React.PropTypes.number.isRequired,
+    smallImage: PropTypes.shape({
+      height: PropTypes.number.isRequired,
+      width: PropTypes.number.isRequired,
     }).isRequired,
 
     // the size of the zoomed-in image
-    zoomImage: React.PropTypes.shape({
-      height: React.PropTypes.number.isRequired,
-      width: React.PropTypes.number.isRequired,
+    zoomImage: PropTypes.shape({
+      height: PropTypes.number.isRequired,
+      width: PropTypes.number.isRequired,
     }),
   },
 
@@ -102,27 +102,25 @@ function getOffset(el) {
 var ImageMagnifier = React.createClass({
   propTypes: {
     // the size of the magnifier window
-    size: React.PropTypes.number,
+    size: PropTypes.number,
 
     // the offset of the zoom bubble from the cursor
-    cursorOffset: React.PropTypes.shape({
-      x: React.PropTypes.number.isRequired,
-      y: React.PropTypes.number.isRequired,
+    cursorOffset: PropTypes.shape({
+      x: PropTypes.number.isRequired,
+      y: PropTypes.number.isRequired,
     }),
 
     // the URL of the image
-    src: React.PropTypes.string.isRequired,
+    src: PropTypes.string.isRequired,
 
     // the size of the non-zoomed-in image
-    image: React.PropTypes.shape({
-      height: React.PropTypes.number.isRequired,
-      width: React.PropTypes.number.isRequired,
-    }).isRequired,
+    height: PropTypes.number,
+    width: PropTypes.number,
 
     // the size of the zoomed-in image
-    zoomImage: React.PropTypes.shape({
-      height: React.PropTypes.number.isRequired,
-      width: React.PropTypes.number.isRequired,
+    zoomImage: PropTypes.shape({
+      height: PropTypes.number.isRequired,
+      width: PropTypes.number.isRequired,
     }),
   },
 
@@ -175,7 +173,10 @@ var ImageMagnifier = React.createClass({
       <Magnifier
         cursorOffset={this.props.cursorOffset}
         size={this.props.size}
-        smallImage={this.props.image}
+        smallImage={{
+          height: this.props.height || this.img.clientHeight,
+          width: this.props.width || this.img.clientWidth,
+        }}
         src={this.props.src}
         zoomImage={this.props.zoomImage}
         {...this.state}
@@ -186,10 +187,12 @@ var ImageMagnifier = React.createClass({
   render() {
     return (
       <img
-        height={this.props.image.height}
         ref={node => this.img = node}
         src={this.props.src}
-        width={this.props.image.width}
+        style={{
+          height: this.props.height || "auto",
+          width: this.props.width || "100%",
+        }}
       />
     );
   }

--- a/src/ImageMagnifier.js
+++ b/src/ImageMagnifier.js
@@ -35,7 +35,7 @@ var Magnifier = React.createClass({
   render() {
     var props = this.props;
     var halfSize = props.size / 2;
-    var imageSize = this.props.zoomImage ? this.props.zoomImage : getImageSize(this.props.src);
+    var imageSize = props.zoomImage ? props.zoomImage : getImageSize(props.src);
     var magX = imageSize.width / props.smallImage.width;
     var magY = imageSize.height / props.smallImage.height;
     var bgX = -(props.offsetX * magX - halfSize);
@@ -90,8 +90,8 @@ var ImageMagnifier = React.createClass({
       y: PropTypes.number.isRequired,
     }), // the offset of the zoom bubble from the cursor
     src: PropTypes.string.isRequired, // the URL of the image
-    height: PropTypes.number, // the size of the non-zoomed-in image
-    width: PropTypes.number, // the size of the non-zoomed-in image
+    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]), // the size of the non-zoomed-in image
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]), // the size of the non-zoomed-in image
     zoomImage: PropTypes.shape({
       height: PropTypes.number.isRequired,
       width: PropTypes.number.isRequired,
@@ -148,14 +148,17 @@ var ImageMagnifier = React.createClass({
     ReactDOM.render(
       <Magnifier
         cursorOffset={this.props.cursorOffset}
+        offsetX={this.state.offsetX}
+        offsetY={this.state.offsetY}
         size={this.props.size}
         smallImage={{
           height: this.img.clientHeight,
           width: this.img.clientWidth,
         }}
         src={this.props.src}
+        x={this.state.x}
+        y={this.state.y}
         zoomImage={this.props.zoomImage}
-        {...this.state}
       />,
     this.portalElement);
   },
@@ -163,7 +166,7 @@ var ImageMagnifier = React.createClass({
   render() {
     return (
       <img
-        ref={node => this.img = node}
+        ref={(node) => this.img = node}
         src={this.props.src}
         style={{
           height: this.props.height,


### PR DESCRIPTION
- Allow for image and zoomed image height and width to be optional
  - Default image height and width set to "auto" and "100%" respectively to allow for responsiveness
  - Default zoomed image set to original src image size
- Remove `src` from both image and zoomImaged and use just one src
