### PR TITLE
onMouseMove uses client[XY] and fallbacks to page[XY]Offset for IE11

### DIFF
--- a/src/components/ImageMagnifier.js
+++ b/src/components/ImageMagnifier.js
@@ -68,10 +68,10 @@ const ImageMagnifier = React.createClass({
   onMouseMove(e) {
     const offset = getOffset(this.img);
     this.setState({
-      x: e.x + window.scrollX,
-      y: e.y + window.scrollY,
-      offsetX: e.x - offset.x,
-      offsetY: e.y - offset.y
+      x: e.clientX + (window.scrollX || window.pageXOffset),
+      y: e.clientY + (window.scrollY || window.pageYOffset),
+      offsetX: e.clientX - offset.x,
+      offsetY: e.clientY - offset.y
     });
   },
 


### PR DESCRIPTION
I changed `onMouseMove` to use `e.clientX` and `e.clientY` instead of just `x` and `y`.
Also I added the fallback to `pageXOffset` and `pageYOffset` to provide support for IE11, where `scrollX` and `scrollY` aren't available.